### PR TITLE
Task(1040633): Changed version from dotnet 9 to dotnet 10 in Parallaxview sample

### DIFF
--- a/ParallaxViewCustomControl/ParallaxViewCustomControl/CustomControl/CustomListView.cs
+++ b/ParallaxViewCustomControl/ParallaxViewCustomControl/CustomControl/CustomListView.cs
@@ -3,8 +3,17 @@ using System.Collections;
 
 namespace ParallaxViewCustomControl
 {
-    public class CustomListView : ListView, IParallaxView
+    public class CustomListView : CollectionView, IParallaxView
     {
+        public static readonly BindableProperty RowHeightProperty =
+            BindableProperty.Create(nameof(RowHeight), typeof(double), typeof(CustomListView), 0d);
+
+        public double RowHeight
+        {
+            get => (double)GetValue(RowHeightProperty);
+            set => SetValue(RowHeightProperty, value);
+        }
+
         public double ItemMargin { get; set; }
         public Size ScrollableContentSize { get; set; }
 
@@ -20,11 +29,11 @@ namespace ParallaxViewCustomControl
 #endif
         }
 
-        private void CustomListView_Scrolled(object? sender, ScrolledEventArgs e)
+        private void CustomListView_Scrolled(object? sender, ItemsViewScrolledEventArgs e)
         {
-            if (sender is ListView listView && Scrolling != null)
+            if (sender is CollectionView collectionView && Scrolling != null)
             {
-                Scrolling.Invoke(this, new ParallaxScrollingEventArgs(e.ScrollX, e.ScrollY, false));
+                Scrolling.Invoke(this, new ParallaxScrollingEventArgs(e.HorizontalOffset, e.VerticalOffset, false));
             }
         }
 
@@ -33,12 +42,12 @@ namespace ParallaxViewCustomControl
             var minimumSize = new Size(40, 40);
             Size request = Size.Zero;
 
-            if (ItemsSource is IList list && HasUnevenRows == false && RowHeight > 0 && !IsGroupingEnabled)
+            if (ItemsSource is IList list && RowHeight > 0)
             {
                 request = new Size(widthConstraint, list.Count * RowHeight + ItemMargin);
             }
 
-            this.ScrollableContentSize = new SizeRequest(request, minimumSize);
+            this.ScrollableContentSize = new Size(request.Width, Math.Max(request.Height, minimumSize.Height));
             return base.MeasureOverride(widthConstraint, heightConstraint);
         }
     }

--- a/ParallaxViewCustomControl/ParallaxViewCustomControl/CustomControl/CustomListView.cs
+++ b/ParallaxViewCustomControl/ParallaxViewCustomControl/CustomControl/CustomListView.cs
@@ -5,6 +5,7 @@ namespace ParallaxViewCustomControl
 {
     public class CustomListView : CollectionView, IParallaxView
     {
+        // row height property is created for fixed item height and to calculate the total ScrollableContentSize for ParallaxView
         public static readonly BindableProperty RowHeightProperty =
             BindableProperty.Create(nameof(RowHeight), typeof(double), typeof(CustomListView), 0d);
 

--- a/ParallaxViewCustomControl/ParallaxViewCustomControl/MainPage.xaml
+++ b/ParallaxViewCustomControl/ParallaxViewCustomControl/MainPage.xaml
@@ -14,30 +14,29 @@
 
             <parallax:SfParallaxView Source="{x:Reference Name = listview}" x:Name="parallaxview" >
                 <parallax:SfParallaxView.Content>
-                    <Image BackgroundColor="Transparent" Source="{Binding Image}" HorizontalOptions="Fill" VerticalOptions="Fill" Aspect="AspectFill" />
+                    <Image Source="{Binding Image}" Aspect="AspectFill" />
                 </parallax:SfParallaxView.Content>
             </parallax:SfParallaxView>
 
-            <local:CustomListView x:Name="listview" ItemsSource="{Binding Items}" BackgroundColor="Transparent" RowHeight="100">
-                <ListView.ItemTemplate>
+            <local:CustomListView x:Name="listview" ItemsSource="{Binding Items}" RowHeight="100">
+                <CollectionView.ItemTemplate>
                     <DataTemplate>
-                        <ViewCell>
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="0.5*" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <Image BackgroundColor="Transparent" HeightRequest="90" HorizontalOptions="CenterAndExpand" 
-                                 WidthRequest="90" Source="{Binding ItemImage}" Grid.Column="0" VerticalOptions="CenterAndExpand" Aspect="AspectFit" />
-                                <StackLayout BackgroundColor="Transparent" Grid.Column="1" VerticalOptions="CenterAndExpand" 
-                                 HorizontalOptions="FillAndExpand" Orientation="Vertical">
-                                    <Label HorizontalOptions="FillAndExpand" TextColor="White" Text="{Binding Name}"/>
-                                    <Label HorizontalOptions="FillAndExpand" Text="{Binding Author}" TextColor="White"/>
-                                </StackLayout>
-                            </Grid>
-                        </ViewCell>
+                        <Grid >
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="0.5*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="100"/>
+                            </Grid.RowDefinitions>
+                            <Image  HeightRequest="90" HorizontalOptions="Center" WidthRequest="90" Source="{Binding ItemImage}" VerticalOptions="Center" Aspect="AspectFit" />
+                            <VerticalStackLayout  Grid.Column="1" VerticalOptions="Center">
+                                <Label TextColor="White" Text="{Binding Name}"/>
+                                <Label Text="{Binding Author}" TextColor="White"/>
+                            </VerticalStackLayout>
+                        </Grid>
                     </DataTemplate>
-                </ListView.ItemTemplate>
+                </CollectionView.ItemTemplate>
             </local:CustomListView>
         </Grid>
     </ContentPage.Content>

--- a/ParallaxViewCustomControl/ParallaxViewCustomControl/ParallaxViewCustomControl.csproj
+++ b/ParallaxViewCustomControl/ParallaxViewCustomControl/ParallaxViewCustomControl.csproj
@@ -43,8 +43,8 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.18362.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.18362.0</TargetPlatformMinVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/ParallaxViewGettingStarted/ParallaxViewGettingStarted/MainPage.xaml
+++ b/ParallaxViewGettingStarted/ParallaxViewGettingStarted/MainPage.xaml
@@ -10,16 +10,16 @@
         <Grid>
 
             <Grid.BindingContext>
-                <local:ParallaxViewModel x:Name="viewModel"/>
+                <local:ParallaxViewModel/>
             </Grid.BindingContext>
             
             <parallax:SfParallaxView Source="{x:Reference Name = listview}" x:Name="parallaxview" >
                 <parallax:SfParallaxView.Content>
-                    <Image BackgroundColor="Transparent" Source="{Binding Image}" HorizontalOptions="Fill" VerticalOptions="Fill" Aspect="AspectFill" />
+                    <Image Source="{Binding Image}" Aspect="AspectFill" />
                 </parallax:SfParallaxView.Content>
             </parallax:SfParallaxView>
 
-            <list:SfListView x:Name="listview" ItemsSource="{Binding Items}" BackgroundColor="Transparent" ItemSize="100">
+            <list:SfListView x:Name="listview" ItemsSource="{Binding Items}" ItemSize="100">
                 <list:SfListView.ItemTemplate>
                     <DataTemplate>
                         <Grid>
@@ -27,12 +27,11 @@
                                 <ColumnDefinition Width="0.5*" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <Image BackgroundColor="Transparent" HeightRequest="90" HorizontalOptions="Center"
-                                    WidthRequest="90" Source="{Binding ItemImage}" Grid.Column="0" VerticalOptions="Center" Aspect="AspectFit" />
-                            <StackLayout BackgroundColor="Transparent" Grid.Column="1" VerticalOptions="Center" Orientation="Vertical">
+                            <Image HeightRequest="90" HorizontalOptions="Center" WidthRequest="90" Source="{Binding ItemImage}" VerticalOptions="Center" Aspect="AspectFit" />
+                            <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
                                 <Label TextColor="White" Text="{Binding Name}"/>
                                 <Label Text="{Binding Author}" TextColor="White"/>
-                            </StackLayout>
+                            </VerticalStackLayout>
                         </Grid>
                     </DataTemplate>
                 </list:SfListView.ItemTemplate>


### PR DESCRIPTION
## **AI Usage**
Code Studio used in this PR/MR? No

## **Description**
Updated the Parallax View sample project to target **.NET 10** instead of **.NET 9** and removed deprecated MAUI API usages from the sample code.

The changes include replacing obsolete layout options such as:
- `CenterAndExpand`
- `FillAndExpand`

and removing deprecated cell-based implementations such as:
- `ViewCell`

to ensure compatibility with the latest .NET and MAUI versions.

## **Purpose/Benefits of the Feature**
- Ensure Parallax View samples are compatible with .NET 10.
- Remove deprecated MAUI APIs and warnings from sample projects.
- Align sample code with current MAUI recommendations and best practices.
- Improve maintainability and future compatibility of the samples.
- Enable successful build and validation in .NET 10 environments.

## **Use Cases**
- Running Parallax View samples using .NET 10 SDK.
- Verifying Parallax View behavior on .NET 10-supported platforms.
- Supporting developers evaluating Parallax View with the latest .NET release.
- Providing sample code that follows current MAUI standards.
- Eliminating deprecated API warnings during build.

## **Solution Description**
Updated the Parallax View sample project's target framework configuration to .NET 10.

Additionally:
- Replaced deprecated layout options such as `CenterAndExpand` and `FillAndExpand` with supported alternatives.
- Removed usage of deprecated `ViewCell` implementations.
- Updated sample code to align with current MAUI API recommendations.

These changes ensure that the sample project builds and runs successfully using the .NET 10 SDK while remaining free from deprecated API usage.

## **Behavioral Changes**
- Parallax View sample projects now target .NET 10.
- Deprecated MAUI APIs have been removed from the sample code.
- Build-time warnings related to obsolete APIs are eliminated.
- No functional changes to Parallax View behavior.
- No API changes in the control itself.
- Samples can now be built, run, and validated using .NET 10 and current MAUI versions.